### PR TITLE
Deprecate go-bindata in favor of Go embed

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "revealjs"]
-	path = revealjs
-	url = git@github.com:hakimel/reveal.js.git
 [submodule "assets/revealjs"]
 	path = assets/revealjs
 	url = git@github.com:hakimel/reveal.js.git

--- a/assets/templates/slide.html
+++ b/assets/templates/slide.html
@@ -29,7 +29,6 @@
         </section>
       </div>
     </div>
-    <script src="revealjs/lib/js/head.min.js"></script>
     <script src="revealjs/js/reveal.js"></script>
 
     <script>

--- a/server.go
+++ b/server.go
@@ -1,6 +1,7 @@
 package revealgo
 
 import (
+	"embed"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -11,6 +12,12 @@ import (
 	"strings"
 	"text/template"
 )
+
+//go:embed assets/revealjs
+var revealjs embed.FS
+
+//go:embed assets/templates/slide.html
+var slideTemplate string
 
 type Server struct {
 	port int
@@ -42,7 +49,7 @@ type assetHandler struct {
 
 func (h *assetHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	filepath := h.assetPath + r.URL.Path
-	data, err := Asset(filepath)
+	data, err := revealjs.ReadFile(filepath)
 	if err != nil {
 		http.NotFound(w, r)
 		return
@@ -69,14 +76,8 @@ func (h *rootHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	data, err := Asset("assets/templates/slide.html")
-	if err != nil {
-		log.Printf("error:%v", err)
-		http.NotFound(w, r)
-		return
-	}
 	tmpl := template.New("slide template")
-	tmpl.Parse(string(data))
+	tmpl.Parse(slideTemplate)
 	if err != nil {
 		log.Printf("error:%v", err)
 		http.NotFound(w, r)


### PR DESCRIPTION
Hey! Funny story, days ago I was about to retake a personal old project that had the same objective as yours but delivered far less than revealgo :sweat_smile:. It was a no brainer to throw away that old project and look on what I could help over here. 

Since I do not want to be too disruptive I did a couple of small changes. Starting with using Go embed instead of go-bindata for the assets. I have already tested it locally and it is working, so please let me know what do you think about it.

Regards,

PS: Have you think on adding WebSockets support and enable the [multiplex](https://revealjs.com/multiplex/) revealjs plugin? It does not seems that simple but I tempted to give it a try.