### PR TITLE
Define http handlers as functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ _test
 *.test
 *.prof
 tmp/
-example.md
+/example.md
 cover.out
 original.css
+.vscode/

--- a/testdata/example.md
+++ b/testdata/example.md
@@ -1,0 +1,51 @@
+# Markdown Demo
+
+## External 1.1
+
+Content 1.1
+
+Note: This will only appear in the speaker notes window.
+
+___
+
+## External 1.2
+
+Content 1.2
+
+---
+
+## External 2
+
+Content 2.1
+
+___
+
+## External 3.1
+
+Content 3.1
+
+___
+
+## External 3.2
+
+Content 3.2
+
+___
+
+## External 3.3
+
+![External Image](https://s3.amazonaws.com/static.slid.es/logo/v2/slides-symbol-512x512.png)
+
+___
+
+## External 3.4
+
+![External Image](testdata/markdown.svg)
+
+---
+
+## Another one!
+
+---
+
+## Fin

--- a/testdata/markdown.svg
+++ b/testdata/markdown.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="208" height="128" viewBox="0 0 208 128"><rect width="198" height="118" x="5" y="5" ry="10" stroke="#000" stroke-width="10" fill="none"/><path d="M30 98V30h20l20 25 20-25h20v68H90V59L70 84 50 59v39zm125 0l-30-33h20V30h20v35h20z"/></svg>


### PR DESCRIPTION
## Background

Hi, is me again :octocat:. I just finished with the revealgo + multiplex integration, and you can see how it looks on [this branch](https://github.com/jossemarGT/revealgo/tree/feature/support-slide-multiplex). Unfortunately, when I was cleaning up what I did on said branch I found myself doing a mild refactor in the process, so instead of disturbing you with a big change I would rather split it in two separated pull requests (so expect another one coming from my side).

## What changed?

I did a mild refactor with  the sole goal of reutilizing the exisiting handlers alongside others and the stdlib ones. In this way the upcoming changes can be designed as small "middlewares" insted of complex types with some business logic on them.

By the way, I _think_ this might solve #4 since now revealgo uses the `http.Dir` stdlib function to serve the content. Either way, I am not 100% since I am not a Windows user :man_shrugging:.