### PR TITLE
Automate cross-compilation process using goreleaser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ tmp/
 cover.out
 original.css
 .vscode/
+dist/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,39 @@
+project_name: revealgo
+before:
+  hooks:
+  - git submodule update --init --recursive
+build:
+  binary: revealgo
+  main: cmd/revealgo/reveal.go
+  goos:
+    - darwin
+    - linux
+    - windows
+  goarch:
+    - 386
+    - amd64
+    - arm
+    - arm64
+  ignore:
+    - goos: windows
+      goarch: arm
+  env:
+    - CGO_ENABLED=0
+archives:
+- name_template: "{{.Binary}}_{{ .Version }}_{{.Os}}-{{.Arch}}"
+  replacements:
+    amd64: 64bit
+    386: 32bit
+    arm: ARM
+    arm64: ARM64
+    darwin: macOS
+    linux: Linux
+    windows: Windows
+  format: tar.gz
+  format_overrides:
+    - goos: windows
+      format: zip
+  files:
+  - LICENSE
+snapshot:
+  name_template: SNAPSHOT-{{ .Commit }}

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,64 @@
+# Contributing to revealgo
+
+:tada: First off, thanks for taking the time to contribute! :tada:
+
+## How to build this project
+
+As any other Golang written binary, `revealgo` can be build on different
+manners.
+
+### Local environment build
+
+This one was already addressed on the [README.md](../README.md) file. Basically
+what you need is to perform the followings steps to have your local `revealgo`
+binary:
+
+1. Clone this repository
+2. Update git-submodule references
+3. Either `go build [...]` or `go install [...]` this repository
+
+```shell
+$ git clone https://github.com/yusukebe/revealgo.git
+$ cd revealgo
+$ git submodule update --init --recursive
+$ go install ./cmd/revealgo
+```
+
+### Cross-platform binaries build
+
+For CI and Release builds another tool, called
+[goreleaser](https://goreleaser.com/intro/), is used for orchestating the
+cross-platform binaries management. Assuming you already have said tool in your
+local environment, a snapshot build can be done by:
+
+1. Clone this repository
+2. Run `goreleaser` build for snapshots using the `--snapshot` flag
+
+```shell
+$ git clone https://github.com/yusukebe/revealgo.git
+$ cd revealgo
+$ goreleaser build --snapshot --rm-dist
+$ tree dist
+dist
+├── config.yaml
+├── revealgo_darwin_amd64
+│   └── revealgo
+├── revealgo_darwin_arm64
+│   └── revealgo
+├── revealgo_linux_386
+│   └── revealgo
+├── revealgo_linux_amd64
+│   └── revealgo
+├── revealgo_linux_arm_6
+│   └── revealgo
+├── revealgo_linux_arm64
+│   └── revealgo
+├── revealgo_windows_386
+│   └── revealgo.exe
+└── revealgo_windows_amd64
+└── revealgo.exe
+```
+
+**NOTE:** `goreleaser` has an strong opinion about where the binary version
+should come from, which is the git tag. Bear this in mind when you use the
+`goreleaser release` subcommand.


### PR DESCRIPTION
Hey @yusukebe.

As we discussed on #11, I have tackled the following enhancement:

> -  Statically compile revealgo for Windows, MacOS and Linux operative systems (at least for x64 architectures)

We can continue doing the usual `go build` if we need to, but when the time comes to cross-compile multiple OS's and architectures [gorelease](https://goreleaser.com/) is a better solution.

Please take a look, and let's discuss any rough edge.

PS: I do not think having submodules is as bad as we initially thought. At the end, we would need to move that logic into another tool, for example: a shell script that reads a file which does several `curl` commands.