### PR TITLE
Add GitHub actions for CI and Release processes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,37 @@
+name: ci
+
+on:
+  pull_request:
+  push:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          submodules: 'recursive'
+      -
+        name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.17
+      - 
+        name: Lint
+        uses: golangci/golangci-lint-action@v2
+        with:
+          version: v1.29
+      -
+        name: Test
+        run: |
+          go test ./...
+      -
+        name: Check goreleaser configuration
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          distribution: goreleaser
+          version: latest
+          args: check

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,33 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - '*'
+
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      -
+        name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.17
+      -
+        name: Build release artifacts
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -5,6 +5,8 @@ before:
 build:
   binary: revealgo
   main: cmd/revealgo/reveal.go
+  ldflags:
+  - -s -w -X github.com/yusukebe/revealgo.Version=v{{.Version}}
   goos:
     - darwin
     - linux

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -59,6 +59,32 @@ dist
 └── revealgo.exe
 ```
 
-**NOTE:** `goreleaser` has an strong opinion about where the binary version
-should come from, which is the git tag. Bear this in mind when you use the
-`goreleaser release` subcommand.
+## How to cut a new release
+
+As mentioned in the section above, this project relies on
+[goreleaser](https://goreleaser.com/intro/) for cross-platform builds, packaging
+and release.
+
+The release process will be triggered **once a new git tag is pushed** to
+GitHub, regardless of the branch it is associated with. The process goes as follows:
+
+1. A new git tag is created following [semver](https://semver.org/) conventions
+2. The git tag is pushed to `revealgo`'s repository
+3. A GitHub action will take care of the release process:
+   - Run linting
+   - Run `goreleaser release --rm-dist`
+   - Publish new release as a [draft](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository)
+
+Upon success, the maintainer will take care of updating the release information
+and changing it out from draft mode.
+
+To test the release process locally you can run any of the following commands:
+
+```
+# Run release process WITHOUT checking for unstagged changes and AVOIDING to plublish
+$ goreleaser release --rm-dist --skip-validate --skip-publish
+
+# Run FULL release process. Requires the GITHUB_TOKEN env. variable.
+# Read more here: https://goreleaser.com/scm/github/
+$ goreleaser release --rm-dist
+```

--- a/server_test.go
+++ b/server_test.go
@@ -28,7 +28,7 @@ func TestContentHandler(t *testing.T) {
 	}
 
 	buf := new(bytes.Buffer)
-	buf.ReadFrom(res.Body)
+	_, _ = buf.ReadFrom(res.Body)
 	s := buf.String()
 
 	matches := []struct {

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package revealgo
 
-const Version string = "v1.1.0"
+var Version string = "v1.1.0"


### PR DESCRIPTION
Ok, this pull request was created as a *draft* on on purpose due to:

1. When a contributor adds a github action, I recall the maintainer must approve it first, berfore it start working.
2. I need to discuss some details about how do you (@yusukebe) imagine the release process should look like.

I think the fastest approach would be to let `gorelease` to create the release on GitHub by itself, this is supported by it out of the box. The relase will be triggered when a git tag is pushed, and this will be created as a *draft* or *pre-release* so you can manually change anything you like aftewards.

What do you think? Should we go that way or do you have other idea?

And yes, you will need to test the process with a dummy release (ie: v1.1.1 or v1.2.0-pre)

PS: I will clean up the branch history after we agree on how to proceed.