### PR TITLE
add template slide option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ cover.out
 original.css
 .vscode/
 dist/
+/revealgo

--- a/README.md
+++ b/README.md
@@ -43,10 +43,13 @@ Available options:
 -p, --port            TCP port number of this server (default: 3000)
 --theme               Slide theme or original css file name. default themes:
                       beige, black, blood, league, moon, night, serif, simple, sky, solarized, and white (default: black.css)
+--template            Custom HTML template file name. default template: slide
+--disable-auto-open   Disable automatic opening of the browser
 --transition          Transition effect for slides: default, cube, page, concave, zoom, linear, fade, none (default: default)
 --separator           Horizontal slide separator characters (default: ^---)
 --vertical-separator  Vertical slide separator characters (default: ^___)
---multiplex           Enable slide multiplex
+--multiplex           Enable slide multiplexing
+-v, --version         Show the version
 ```
 
 ### Screenshots
@@ -59,7 +62,7 @@ Open the server address with your web browser:
 
 ![Slides](https://cloud.githubusercontent.com/assets/10682/12741672/f9cda548-c9c1-11e5-9c21-fcaf1af3cdf4.png)
 
-### Sample Makrdown
+### Sample Markdown
 
 ```text
 ## This is an H2 Title
@@ -110,6 +113,14 @@ $ curl http://localhost:3000/ > slide.html
 ```
 
 Edit `slide.html`, and then open `http://localhost:3000/slide.html` with your browser. A slide with the modified configurations will come up.
+
+### Customize Slide template
+
+A custom `slide.html` can also be provided using the `--template` option, or putting a `slide.html` next to your custom theme file.
+This allows you to use templating within your `slide.html`
+
+You could use the `slide.html` output from your localhost, or grab a copy of the orignal asset to use as the base.
+This can be obtained from: <https://github.com/yusukebe/revealgo/blob/master/assets/templates/slide.html>
 
 ### Using slide multiplex
 

--- a/cli.go
+++ b/cli.go
@@ -24,6 +24,7 @@ type CLI struct {
 type CLIOptions struct {
 	Port              int    `short:"p" long:"port" description:"TCP port number of this server" default:"3000"`
 	Theme             string `long:"theme" description:"Slide theme or original css file name. default themes: beige, black, blood, league, moon, night, serif, simple, sky, solarized, and white" default:"black.css"`
+	Template		  string `long:"template" description:"Custom HTML template file name. default template: slide"`
 	DisableAutoOpen   bool   `long:"disable-auto-open" description:"Disable automatic opening of the browser"`
 	Transition        string `long:"transition" description:"Transition effect for slides: default, cube, page, concave, zoom, linear, fade, none" default:"default"`
 	Separator         string `long:"separator" description:"Horizontal slide separator characters" default:"^---"`
@@ -79,14 +80,22 @@ func (cli *CLI) serve(args []string) {
 		originalTheme = true
 	}
 
+	_, err = os.Stat(opts.Template)
+	originalTemplate := false
+	if err == nil {
+		originalTemplate = true
+	}
+
 	server := Server{
 		port: opts.Port,
 	}
 	param := ServerParam{
 		Path:              args[0],
 		Theme:             addExtention(opts.Theme, "css"),
+		Template:          addExtention(opts.Template, "html"),
 		Transition:        opts.Transition,
 		OriginalTheme:     originalTheme,
+		OriginalTemplate:  originalTemplate,
 		DisableAutoOpen:   opts.DisableAutoOpen,
 		Separator:         opts.Separator,
 		VerticalSeparator: opts.VerticalSeparator,

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package revealgo
 
-var Version string = "v1.2.2"
+var Version string = "v1.3.0"


### PR DESCRIPTION
Add a `--template` option so users can supply their own version of templated version of `slide.html`.
Also use `--theme` if provided to infer a custom `slide.html` ... aka bundling it with a theme css.